### PR TITLE
Flake8 compliance (mostly)

### DIFF
--- a/spritesheetExporter/spritesheetexporter.py
+++ b/spritesheetExporter/spritesheetexporter.py
@@ -1,9 +1,15 @@
 from krita import (krita, InfoObject)
 from math import sqrt, ceil, floor
-from . import uispritesheetexporter # manages the dialog that lets you set user preferences before applying the script
-from pathlib import Path #for path operations # who'd have guessed
 
-from PyQt5.QtWidgets import QWidget, QLabel, QMessageBox # for debug messages
+from . import uispritesheetexporter
+# manages the dialog that lets you set user preferences
+# before applying the script
+
+from pathlib import Path
+# for path operations (who'd have guessed)
+
+from PyQt5.QtWidgets import QWidget, QLabel, QMessageBox
+# for debug messages
 
 
 class SpritesheetExporter(object):
@@ -11,8 +17,11 @@ class SpritesheetExporter(object):
     def __init__(self):
         # user-defined variables
         self.exportName = "Spritesheet"
-        self.exportDir = Path.home() #remember this is a Path, not a string, and as such you can't do string operations on it (unless you convert it first)
-        self.spritesExportDir = "" # this is a Path too. Trust me.
+        self.exportDir = Path.home()
+        # remember this is a Path, not a string, and as such
+        # you can't do string operations on it (unless you convert it first)
+        self.spritesExportDir = ""
+        # this is a Path too. Trust me.
         self.isDirectionHorizontal = True
         self.rows = 0
         self.columns = 0
@@ -24,23 +33,26 @@ class SpritesheetExporter(object):
 
     def positionLayer(self, layer, imgNum, width, height):
         if self.isDirectionHorizontal:
-            layer.move((imgNum % self.columns) * width, (int(imgNum/self.columns)) * height)
+            layer.move((imgNum % self.columns) * width,
+                       (int(imgNum/self.columns)) * height)
         else:
-            layer.move(int(imgNum / self.rows) * width, (imgNum % self.rows) * height)
+            layer.move(int(imgNum / self.rows) * width,
+                       (imgNum % self.rows) * height)
 
-
-    # export all frames of the animation in a temporary folder as png
-    # create a new document of the right dimensions according to self.rows and self.columns
-    # position each exported frame in the new doc according to its name
-    # export the doc (aka the spritesheet)
-    # remove tmp folder if needed
-    def export(self, debugging = False):
+    # - export all frames of the animation in a temporary folder as png
+    # - create a new document of the right dimensions
+    #   according to self.rows and self.columns
+    # - position each exported frame in the new doc according to its name
+    # - export the doc (aka the spritesheet)
+    # - remove tmp folder if needed
+    def export(self, debugging=False):
 
         addedFolder = False
-        # create a temporary export directory for the individual sprites if the user didn't set any
+        # create a temporary export directory for the individual sprites
+        # if the user didn't set any
         if self.spritesExportDir == "":
-            self.spritesExportDir = self.exportDir.joinpath(self.exportName + "_sprites")
-
+            self.spritesExportDir = \
+                self.exportDir.joinpath(self.exportName + "_sprites")
 
         if not self.overwrite and self.spritesExportDir.exists():
             exportNum = 0
@@ -48,18 +60,22 @@ class SpritesheetExporter(object):
             parentPath = self.spritesExportDir.parent
             folder = str(self.spritesExportDir.parts[-1])
 
-            # in case the user has a folder with the exact same name as my temporary one
+            # in case the user has a folder with the exact same name
+            # as my temporary one
             while (parentPath.joinpath(folder + str(exportNum)).exists()):
                 exportNum += 1
 
-            self.spritesExportDir = parentPath.joinpath(folder + str(exportNum))
-            # if overwrite, spritesExportDir's value is taken from the user-set choices in the dialog
+            self.spritesExportDir = \
+                parentPath.joinpath(folder + str(exportNum))
 
-        # this will always be called if not overwrite because it will always create a new export folder
+        # if overwrite, spritesExportDir's value is taken
+        # from the user-set choices in the dialog
+
+        # this will always be called if not overwrite
+        # because it will always create a new export folder
         if not (self.spritesExportDir).exists():
             addedFolder = True
             (self.spritesExportDir).mkdir()
-
 
         # render animation in the sprites export folder
         doc = Krita.instance().activeDocument()
@@ -73,16 +89,29 @@ class SpritesheetExporter(object):
             self.step = 1
         doc.setCurrentTime(self.start)
         if(debugging):
-            print("animation Length: " + str(doc.animationLength()) + "; full clip self.start: " + str(doc.fullClipRangeStartTime()) + "; full clip self.end: " + str(doc.fullClipRangeEndTime()) + "; playback self.start time: " + doc.playbackStartTime() + "; playback self.end time: " + playbackEndTime())
+            print("animation Length: " +
+                  str(doc.animationLength()) +
+                  "; full clip self.start: " +
+                  str(doc.fullClipRangeStartTime()) +
+                  "; full clip self.end: " +
+                  str(doc.fullClipRangeEndTime()) +
+                  "; playback self.start time: " +
+                  doc.playbackStartTime() +
+                  "; playback self.end time: " +
+                  playbackEndTime())
         framesNum = ((self.end + 1) - self.start)/self.step
-        # it would be better to have the default value be from first to last effective frame instead of asking the user to correctly set the Start and End anim values each time, but as of now krita can't I think
-        doc.setBatchmode(True) # so it won't show the export dialog window
+        # it would be better to have the default value be
+        # from first to last effective frame instead of asking the user
+        # to correctly set the Start and End anim values each time,
+        # but as of now krita can't I think
+        doc.setBatchmode(True)  # so it won't show the export dialog window
         tmpNum = self.start
         while(doc.currentTime() <= self.end):
-            doc.exportImage(str(self.spritesExportDir.joinpath(self.exportName + "_" + str(tmpNum).zfill(3) + ".png")), InfoObject())
+            imageName = self.exportName + "_" + str(tmpNum).zfill(3) + ".png"
+            imagePath = str(self.spritesExportDir.joinpath(imageName))
+            doc.exportImage(imagePath, InfoObject())
             doc.setCurrentTime(doc.currentTime() + self.step)
             tmpNum += self.step
-
 
         # getting current document info
         # so we can copy it over to the new document
@@ -92,44 +121,53 @@ class SpritesheetExporter(object):
         depth = doc.colorDepth()
         profile = doc.colorProfile()
         res = doc.resolution()
-        #print(dir(doc))
-
+        # print(dir(doc))
 
         # getting a default value for rows and columns
         if (self.rows == 0) and (self.columns == 0):
-        # square fit
+            # square fit
             self.columns = ceil(sqrt(framesNum))
             self.rows = ceil(float(framesNum)/self.columns)
-        # or one row?
-        #self.rows = 1
-        #self.columns = framesNum
+            # or one row?
+            # self.rows = 1
+            # self.columns = framesNum
             if (debugging):
-                print("self.rows: " + str(self.rows) + "; self.columns: " + str(self.columns))
+                print("self.rows: " + str(self.rows) +
+                      "; self.columns: " + str(self.columns))
 
         # if only one is specified, guess the other
         elif (self.rows == 0):
             self.rows = ceil(float(framesNum)/self.columns)
-        # though if I have to guess the number of columns it may also change the (user-set) number of rows
-        # for example if you want ten rows from twelve sprites
-        # instead of two rows of two and eight of one
+        # Though if I have to guess the number of columns,
+        # it may also change the (user-set) number of rows.
+        # For example, if you want ten rows from twelve sprites
+        # instead of two rows of two and eight of one,
         # you'll have six rows of two
         elif (self.columns == 0):
             self.columns = ceil(float(framesNum)/self.rows)
             self.rows = ceil(float(framesNum)/self.columns)
 
-
         # creating a new document where we'll put our sprites
-        sheet = Krita.instance().createDocument(self.columns * width, self.rows * height, self.exportName, col, depth, profile, res)
+        sheet = Krita.instance().createDocument(
+            self.columns * width,
+            self.rows * height,
+            self.exportName,
+            col, depth, profile, res)
         if (debugging):
             print("new doc name: " + sheet.name())
             print("old doc width: " + str(width))
             print("num of frames: " + str(framesNum))
             print("new doc width: " + str(sheet.width()))
 
-
-        # for debugging when the result of print() is not available
-        #        QMessageBox.information(QWidget(), i18n("Debug 130"), i18n("step: " + str(self.step) + "; end: " + str(self.end) + "; start: " + str(self.start) + "; rows: " + str(self.rows) + "; columns: " + str(self.columns)) + "; frames number: " + str(framesNum))
-
+            # for debugging when the result of print() is not available
+            # QMessageBox.information(QWidget(), i18n("Debug 130"),
+            #                         i18n("step: " + str(self.step) +
+            #                              "; end: " + str(self.end) +
+            #                              "; start: " + str(self.start) +
+            #                              "; rows: " + str(self.rows) +
+            #                              "; columns: " + str(self.columns) +
+            #                              "; frames number: " +
+            #                              str(framesNum)))
 
         # adding our sprites to the new document
         # and moving them to the right position
@@ -137,27 +175,36 @@ class SpritesheetExporter(object):
         root_node = sheet.rootNode()
 
         while (imgNum <= self.end):
-            img = str(self.spritesExportDir.joinpath(self.exportName + "_" + str(imgNum).zfill(3) + ".png"))
+            imageName = self.exportName + "_" + str(imgNum).zfill(3) + ".png"
+            img = str(self.spritesExportDir.joinpath(imageName))
             layer = sheet.createFileLayer(img, img, "ImageToSize")
             root_node.addChildNode(layer, None)
-            self.positionLayer(layer=layer, imgNum=((imgNum-self.start)/self.step), width=width, height=height)
+            self.positionLayer(
+                layer=layer,
+                imgNum=((imgNum-self.start)/self.step),
+                width=width,
+                height=height)
             # I need to merge down each layer or they don't show
             layer.mergeDown()
             if self.removeTmp:
                 # removing temporary sprites exports
                 Path(img).unlink()
             if (debugging):
-                print("image " + str(imgNum-self.start) + " name: " + img + " at pos:")
+                print("image " + str(imgNum-self.start) +
+                      " name: " + img +
+                      " at pos:")
                 print(layer.position())
             imgNum += self.step
 
-
         # export the document to the export location
-        sheet.setBatchmode(True) # so it won't show the export dialog window
+        sheet.setBatchmode(True)  # so it won't show the export dialog window
         if debugging:
-            print("exporting spritesheet to " + str(self.exportDir.joinpath(self.exportName)))
+            print("exporting spritesheet to " +
+                  str(self.exportDir.joinpath(self.exportName)))
 
-        sheet.exportImage(str(self.exportDir.joinpath(self.exportName)) + ".png", InfoObject())
+        exportImagePath = \
+            str(self.exportDir.joinpath(self.exportName)) + ".png"
+        sheet.exportImage(exportImagePath, InfoObject())
 
         # and remove the empty tmp folder when you're done
         if self.removeTmp:

--- a/spritesheetExporter/spritesheetexporter.py
+++ b/spritesheetExporter/spritesheetexporter.py
@@ -46,7 +46,7 @@ class SpritesheetExporter(object):
             exportNum = 0
 
             parentPath = self.spritesExportDir.parent
-            folder = str(self.spritesExportDir.parts[len(self.spritesExportDir.parts) -1])
+            folder = str(self.spritesExportDir.parts[-1])
 
             # in case the user has a folder with the exact same name as my temporary one
             while (parentPath.joinpath(folder + str(exportNum)).exists()):

--- a/spritesheetExporter/spritesheetexporter.py
+++ b/spritesheetExporter/spritesheetexporter.py
@@ -27,7 +27,7 @@ class SpritesheetExporter(object):
             layer.move((imgNum % self.columns) * width, (int(imgNum/self.columns)) * height)
         else:
             layer.move(int(imgNum / self.rows) * width, (imgNum % self.rows) * height)
-            
+
 
     # export all frames of the animation in a temporary folder as png
     # create a new document of the right dimensions according to self.rows and self.columns
@@ -40,26 +40,26 @@ class SpritesheetExporter(object):
         # create a temporary export directory for the individual sprites if the user didn't set any
         if self.spritesExportDir == "":
             self.spritesExportDir = self.exportDir.joinpath(self.exportName + "_sprites")
-       
-       
+
+
         if not self.overwrite and self.spritesExportDir.exists():
             exportNum = 0
-        
+
             parentPath = self.spritesExportDir.parent
             folder = str(self.spritesExportDir.parts[len(self.spritesExportDir.parts) -1])
-        
+
             # in case the user has a folder with the exact same name as my temporary one
             while (parentPath.joinpath(folder + str(exportNum)).exists()):
                 exportNum += 1
-            
+
             self.spritesExportDir = parentPath.joinpath(folder + str(exportNum))
             # if overwrite, spritesExportDir's value is taken from the user-set choices in the dialog
-    
+
         # this will always be called if not overwrite because it will always create a new export folder
         if not (self.spritesExportDir).exists():
             addedFolder = True
             (self.spritesExportDir).mkdir()
-    
+
 
         # render animation in the sprites export folder
         doc = Krita.instance().activeDocument()
@@ -70,32 +70,32 @@ class SpritesheetExporter(object):
             self.end = doc.fullClipRangeEndTime()
         # give default value to step
         if (self.step == 0):
-            self.step = 1 
+            self.step = 1
         doc.setCurrentTime(self.start)
         if(debugging):
             print("animation Length: " + str(doc.animationLength()) + "; full clip self.start: " + str(doc.fullClipRangeStartTime()) + "; full clip self.end: " + str(doc.fullClipRangeEndTime()) + "; playback self.start time: " + doc.playbackStartTime() + "; playback self.end time: " + playbackEndTime())
         framesNum = ((self.end + 1) - self.start)/self.step
         # it would be better to have the default value be from first to last effective frame instead of asking the user to correctly set the Start and End anim values each time, but as of now krita can't I think
-        doc.setBatchmode(True) # so it won't show the export dialog window    
+        doc.setBatchmode(True) # so it won't show the export dialog window
         tmpNum = self.start
         while(doc.currentTime() <= self.end):
             doc.exportImage(str(self.spritesExportDir.joinpath(self.exportName + "_" + str(tmpNum).zfill(3) + ".png")), InfoObject())
             doc.setCurrentTime(doc.currentTime() + self.step)
             tmpNum += self.step
-    
-    
+
+
         # getting current document info
         # so we can copy it over to the new document
         width = doc.width()
         height = doc.height()
         col = doc.colorModel()
-        depth = doc.colorDepth()    
+        depth = doc.colorDepth()
         profile = doc.colorProfile()
         res = doc.resolution()
         #print(dir(doc))
-    
-    
-        # getting a default value for rows and columns    
+
+
+        # getting a default value for rows and columns
         if (self.rows == 0) and (self.columns == 0):
         # square fit
             self.columns = ceil(sqrt(framesNum))
@@ -105,8 +105,8 @@ class SpritesheetExporter(object):
         #self.columns = framesNum
             if (debugging):
                 print("self.rows: " + str(self.rows) + "; self.columns: " + str(self.columns))
-    
-        # if only one is specified, guess the other    
+
+        # if only one is specified, guess the other
         elif (self.rows == 0):
             self.rows = ceil(float(framesNum)/self.columns)
         # though if I have to guess the number of columns it may also change the (user-set) number of rows
@@ -116,7 +116,7 @@ class SpritesheetExporter(object):
         elif (self.columns == 0):
             self.columns = ceil(float(framesNum)/self.rows)
             self.rows = ceil(float(framesNum)/self.columns)
-    
+
 
         # creating a new document where we'll put our sprites
         sheet = Krita.instance().createDocument(self.columns * width, self.rows * height, self.exportName, col, depth, profile, res)
@@ -125,7 +125,7 @@ class SpritesheetExporter(object):
             print("old doc width: " + str(width))
             print("num of frames: " + str(framesNum))
             print("new doc width: " + str(sheet.width()))
-    
+
 
         # for debugging when the result of print() is not available
         #        QMessageBox.information(QWidget(), i18n("Debug 130"), i18n("step: " + str(self.step) + "; end: " + str(self.end) + "; start: " + str(self.start) + "; rows: " + str(self.rows) + "; columns: " + str(self.columns)) + "; frames number: " + str(framesNum))
@@ -135,7 +135,7 @@ class SpritesheetExporter(object):
         # and moving them to the right position
         imgNum = self.start
         root_node = sheet.rootNode()
-        
+
         while (imgNum <= self.end):
             img = str(self.spritesExportDir.joinpath(self.exportName + "_" + str(imgNum).zfill(3) + ".png"))
             layer = sheet.createFileLayer(img, img, "ImageToSize")
@@ -150,15 +150,15 @@ class SpritesheetExporter(object):
                 print("image " + str(imgNum-self.start) + " name: " + img + " at pos:")
                 print(layer.position())
             imgNum += self.step
-            
-        
-        # export the document to the export location       
+
+
+        # export the document to the export location
         sheet.setBatchmode(True) # so it won't show the export dialog window
         if debugging:
             print("exporting spritesheet to " + str(self.exportDir.joinpath(self.exportName)))
 
         sheet.exportImage(str(self.exportDir.joinpath(self.exportName)) + ".png", InfoObject())
-        
+
         # and remove the empty tmp folder when you're done
         if self.removeTmp:
             if addedFolder:

--- a/spritesheetExporter/spritesheetexporterextension.py
+++ b/spritesheetExporter/spritesheetexporterextension.py
@@ -5,36 +5,46 @@ spritesheet exporter from animation timeline
 """
 
 from krita import (Extension, krita)
-from . import uispritesheetexporter # manages the dialog that lets you set user preferences before applying the script
+
+from . import uispritesheetexporter
+# manages the dialog that lets you
+# set user preferences before applying the script
 
 
 class spritesheetExporterExtension(Extension):
 
-    # Always initialise the superclass, This is necessary to create the underlying C++ object
+    # Always initialise the superclass.
+    # This is necessary to create the underlying C++ object
     def __init__(self, parent):
         super().__init__(parent)
 
-# this too is necessary, because "Extension.setup() is abstract and must be overridden" and we inherit from Extension
+    # this too is necessary, because "Extension.setup() is abstract
+    # and must be overridden" and we inherit from Extension
     def setup(self):
         pass
 
     # menu stuff
-    # don't forget to activate the script in krita's preferences or it won't show
-    def createActions (self, window):
-        exportSs = window.createAction("pykrita_spritesheetExporter", "Export As Spritesheet", "tools/scripts")
-        # parameter 1 =  the name that Krita uses to identify the action # where is it used though? For key shortcuts?
+    # don't forget to activate the script in krita's preferences
+    # or it won't show
+    def createActions(self, window):
+        exportSs = window.createAction("pykrita_spritesheetExporter",
+                                       "Export As Spritesheet",
+                                       "tools/scripts")
+        # parameter 1 =  the name that Krita uses to identify the action
+        # (where is it used though? For key shortcuts?)
         # parameter 2 = this script's menu entry name
         # parameter 3 = location of menu entry
 
-        exportSs.setToolTip("Export animation in timeline as spritesheet") # doesn't show tooltip on mouse hover. Why?
+        exportSs.setToolTip("Export animation in timeline as spritesheet")
+        # doesn't show tooltip on mouse hover. Why?
 
         # when you click on the script in the menu it opens the dialog window
         self.ui = uispritesheetexporter.UISpritesheetExporter()
         exportSs.triggered.connect(self.ui.showExportDialog)
 
 
-    # the actual stuff-doing is in the spritesheetexporter.py script
+# the actual stuff-doing is in the spritesheetexporter.py script
 
-app = Krita.instance();
+app = Krita.instance()
 # windows and menu stuff
 Scripter.addExtension(spritesheetExporterExtension(app))

--- a/spritesheetExporter/spritesheetexporterextension.py
+++ b/spritesheetExporter/spritesheetexporterextension.py
@@ -17,9 +17,9 @@ class spritesheetExporterExtension(Extension):
 # this too is necessary, because "Extension.setup() is abstract and must be overridden" and we inherit from Extension
     def setup(self):
         pass
-    
+
     # menu stuff
-    # don't forget to activate the script in krita's preferences or it won't show 
+    # don't forget to activate the script in krita's preferences or it won't show
     def createActions (self, window):
         exportSs = window.createAction("pykrita_spritesheetExporter", "Export As Spritesheet", "tools/scripts")
         # parameter 1 =  the name that Krita uses to identify the action # where is it used though? For key shortcuts?
@@ -30,10 +30,10 @@ class spritesheetExporterExtension(Extension):
 
         # when you click on the script in the menu it opens the dialog window
         self.ui = uispritesheetexporter.UISpritesheetExporter()
-        exportSs.triggered.connect(self.ui.showExportDialog) 
-        
-  
-    # the actual stuff-doing is in the spritesheetexporter.py script 
+        exportSs.triggered.connect(self.ui.showExportDialog)
+
+
+    # the actual stuff-doing is in the spritesheetexporter.py script
 
 app = Krita.instance();
 # windows and menu stuff

--- a/spritesheetExporter/uispritesheetexporter.py
+++ b/spritesheetExporter/uispritesheetexporter.py
@@ -11,12 +11,12 @@ from PyQt5.QtWidgets import (QGridLayout, QVBoxLayout, QFrame, QPushButton,
                              QLineEdit, QWidget, QCheckBox, QDialogButtonBox,
                              QSpacerItem, QSizePolicy)
 import krita
-from pathlib import Path # to have paths work whether it's windows or unix
+from pathlib import Path  # to have paths work whether it's windows or unix
 from . import spritesheetexporter
 
 
 class describedWidget:
-    def __init__ (self, widget, descri, tooltip = ""):
+    def __init__(self, widget, descri, tooltip=""):
         self.widget = widget
         self.descri = descri
         self.tooltip = tooltip
@@ -24,18 +24,22 @@ class describedWidget:
 
 class UISpritesheetExporter(object):
 
-
     def __init__(self):
         # here we don't need super().__init__(parent)
         # maybe it's only for who inherits extensions?
         self.app = krita.Krita.instance()
         self.exp = spritesheetexporter.SpritesheetExporter()
 
-        self.mainDialog = QDialog(self.app.activeWindow().qwindow()) #the main window
-        self.mainDialog.setWindowModality(Qt.NonModal) #The window is not modal and does not block input to other windows.
+        # the main window
+        self.mainDialog = QDialog(self.app.activeWindow().qwindow())
+
+        # the window is not modal and does not block input to other windows
+        self.mainDialog.setWindowModality(Qt.NonModal)
+
         self.mainDialog.setMinimumSize(500, 100)
 
-        self.outerLayout = QVBoxLayout(self.mainDialog) # the box holding everything
+        # the box holding everything
+        self.outerLayout = QVBoxLayout(self.mainDialog)
 
         self.topLayout = QVBoxLayout()
 
@@ -46,7 +50,8 @@ class UISpritesheetExporter(object):
         self.exportDirTx = QLineEdit()
         self.exportDirButt = QPushButton("Change export directory")
         self.exportDirResetButt = QPushButton("Reset to current directory")
-        self.exportDirResetButt.setToolTip("Reset export directory to current .kra document's directory")
+        self.exportDirResetButt.setToolTip(
+            "Reset export directory to current .kra document's directory")
         self.exportDirButt.clicked.connect(self.changeExportDir)
         self.exportDirResetButt.clicked.connect(self.resetExportDir)
         self.exportDir = QHBoxLayout()
@@ -63,13 +68,15 @@ class UISpritesheetExporter(object):
         self.customSettings.setChecked(False)
         self.customSettings.stateChanged.connect(self.toggleHideable)
 
-        self.hideableWidget = QFrame() # QFrames are a type of widget
+        self.hideableWidget = QFrame()  # QFrames are a type of widget
         self.hideableWidget.setFrameShape(QFrame.Panel)
         self.hideableWidget.setFrameShadow(QFrame.Sunken)
         self.hideableLayout = QVBoxLayout(self.hideableWidget)
 
-        # we want to let the user choose if they want the final spritesheet to be horizontally- or vertically-oriented
-        # there is a nifty thing called QButtonGroup() but it doesn't seem to let you add names between each checkbox somehow?
+        # We want to let the user choose if they want the final spritesheet
+        # to be horizontally- or vertically-oriented.
+        # There is a nifty thing called QButtonGroup() but
+        # it doesn't seem to let you add names between each checkbox somehow?
         self.horDir = QCheckBox()
         self.horDir.setChecked(True)
         self.vertDir = QCheckBox()
@@ -81,10 +88,12 @@ class UISpritesheetExporter(object):
         self.spinBoxesWidget = QFrame()
         self.spinBoxesWidget.setFrameShape(QFrame.Panel)
         self.spinBoxesWidget.setFrameShadow(QFrame.Sunken)
-        self.spinBoxes = QHBoxLayout(self.spinBoxesWidget) # a box holding the boxes with rows columns and start end
 
-        self.rows= QSpinBox()
-        self.columns= QSpinBox()
+        # a box holding the boxes with rows columns and start end
+        self.spinBoxes = QHBoxLayout(self.spinBoxesWidget)
+
+        self.rows = QSpinBox()
+        self.columns = QSpinBox()
         self.rows.minimum = 0
         self.columns.minimum = 0
 
@@ -111,7 +120,8 @@ class UISpritesheetExporter(object):
         self.line2 = QFrame()
         self.line2.setFrameShape(QFrame.HLine)
         self.line2.setFrameShadow(QFrame.Sunken)
-        self.OkCancelButtonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.OkCancelButtonBox = \
+            QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         self.OkCancelButtonBox.accepted.connect(self.confirmButton)
         self.OkCancelButtonBox.rejected.connect(self.mainDialog.close)
 
@@ -124,12 +134,11 @@ class UISpritesheetExporter(object):
 
         self.initialize_export()
 
-
-
     # I would have used QFormLayout's addRow
     # except it doesn't let you add a tooltip to the row's name
-    # (adding a tooltip to the whole layout would have been best but doesn't seem possible)
-    def addDescribedWidget(self, parent, listWidgets, align = Qt.AlignLeft):
+    # (adding a tooltip to the whole layout would have been best
+    #  but doesn't seem possible)
+    def addDescribedWidget(self, parent, listWidgets, align=Qt.AlignLeft):
         layout = QGridLayout()
         row = 0
         for widget in listWidgets:
@@ -145,108 +154,131 @@ class UISpritesheetExporter(object):
         parent.addLayout(layout)
         return layout
 
-
     def initialize_export(self):
-
         # putting stuff in boxes
         # and boxes in bigger boxes
         self.exportName.setText(self.exp.exportName)
-        self.addDescribedWidget(parent = self.topLayout, listWidgets = [
-        describedWidget(
-        widget = self.exportName,
-        descri = "Export name:",
-        tooltip = "The name of the exported spritesheet file")])
-        self.addDescribedWidget(parent = self.topLayout, listWidgets = [
-        describedWidget(
-        widget = self.exportDirTx,
-        descri = "Export Directory:",
-        tooltip = "The directory the spritesheet will be exported to")])
+        self.addDescribedWidget(parent=self.topLayout, listWidgets=[
+            describedWidget(
+                widget=self.exportName,
+                descri="Export name:",
+                tooltip="The name of the exported spritesheet file")])
+        self.addDescribedWidget(parent=self.topLayout, listWidgets=[
+            describedWidget(
+                widget=self.exportDirTx,
+                descri="Export Directory:",
+                tooltip="The directory the spritesheet will be exported to")])
 
         self.exportDir.addWidget(self.exportDirButt)
         self.exportDir.addWidget(self.exportDirResetButt)
         self.topLayout.addLayout(self.exportDir)
 
-
-        #self.outerLayout.addItem(self.spacer)
-        self.addDescribedWidget(parent = self.topLayout, listWidgets = [
-        describedWidget(
-        widget = self.customSettings,
-        descri = "Use Custom export Settings:",
-        tooltip = "Whether to set yourself the number of rows, columns, \nfirst and last frame, etc. (checked) \nor use the default values (unchecked) ")])
+        # self.outerLayout.addItem(self.spacer)
+        self.addDescribedWidget(parent=self.topLayout, listWidgets=[
+            describedWidget(
+                widget=self.customSettings,
+                descri="Use Custom export Settings:",
+                tooltip="" +
+                "Whether to set yourself the number of rows, columns, \n" +
+                "first and last frame, etc. (checked) \n" +
+                "or use the default values (unchecked) ")])
 
         self.outerLayout.addLayout(self.topLayout, 0)
 
         # all this stuff will be hideable
         self.direction.addWidget(QLabel("sprites placement direction: \t"))
-        self.addDescribedWidget(parent = self.direction, listWidgets = [
-        describedWidget(
-        widget = self.horDir,
-        descri = "Horizontal:",
-        tooltip = "like so: \n1, 2, 3 \n4, 5, 6 \n7, 8, 9")])
+        self.addDescribedWidget(parent=self.direction, listWidgets=[
+            describedWidget(
+                widget=self.horDir,
+                descri="Horizontal:",
+                tooltip="like so: \n1, 2, 3 \n4, 5, 6 \n7, 8, 9")])
 
-        self.addDescribedWidget(parent = self.direction, listWidgets = [
-        describedWidget(
-        widget = self.vertDir,
-        descri = "Vertical:",
-        tooltip = "like so: \n1, 4, 7 \n2, 5, 8 \n3, 6, 9")])
+        self.addDescribedWidget(parent=self.direction, listWidgets=[
+            describedWidget(
+                widget=self.vertDir,
+                descri="Vertical:",
+                tooltip="like so: \n1, 4, 7 \n2, 5, 8 \n3, 6, 9")])
 
         self.hideableLayout.addLayout(self.direction)
 
         self.hideableLayout.addItem(self.spacerBig)
 
-        defaultsHint = QLabel("Leave any parameter at 0 to get a default value:")
-        defaultsHint.setToolTip("For example with 16 sprites, leaving both rows and columns at 0 \nwill set their defaults to 4 each \nwhile leaving only columns at 0 and rows at 1 \nwill set columns default at 16")
+        defaultsHint = QLabel(
+            "Leave any parameter at 0 to get a default value:")
+        defaultsHint.setToolTip(
+            "For example with 16 sprites, " +
+            "leaving both rows and columns at 0 \n" +
+            "will set their defaults to 4 each \n" +
+            "while leaving only columns at 0 and rows at 1 \n" +
+            "will set columns default at 16")
         self.hideableLayout.addWidget(defaultsHint)
 
+        self.addDescribedWidget(parent=self.spinBoxes, listWidgets=[
+            describedWidget(
+                widget=self.rows,
+                descri="Rows:",
+                tooltip="Number of rows of the spritesheet; \n" +
+                "default is trying to square \n" +
+                "or is assigned depending on columns number"),
+            describedWidget(
+                widget=self.columns,
+                descri="Columns:",
+                tooltip="Number of columns of the spritesheet; \n" +
+                "default is trying to square \n" +
+                "or is assigned depending on rows number")])
 
-        self.addDescribedWidget(parent = self.spinBoxes, listWidgets = [
-        describedWidget(
-        widget = self.rows,
-        descri = "Rows:",
-        tooltip = "Number of rows of the spritesheet; \ndefault is trying to square \nor is assigned depending on columns number"),
-        describedWidget(
-        widget = self.columns,
-        descri = "Columns:",
-        tooltip = "Number of columns of the spritesheet; \ndefault is trying to square \nor is assigned depending on rows number")])
-
-        self.addDescribedWidget(parent = self.spinBoxes, listWidgets = [
-        describedWidget(
-        widget = self.start,
-        descri = "Start:",
-        tooltip = "First frame of the animation timeline (included) to be added to the spritesheet; \ndefault is the Start parameter of the Animation docker"),
-        describedWidget(
-        widget = self.end,
-        descri = "End:",
-        tooltip = "Last frame of the animation timeline (included) to be added to the spritesheet; \ndefault is the End parameter of the Animation docker"),
-        describedWidget(
-        widget = self.step,
-        descri = "Step:",
-        tooltip = "only consider every 'step' frame to be added to the spritesheet; \ndefault is 1 (use every frame)")])
-
+        self.addDescribedWidget(parent=self.spinBoxes, listWidgets=[
+            describedWidget(
+                widget=self.start,
+                descri="Start:",
+                tooltip="" +
+                "First frame of the animation timeline (included) " +
+                "to be added to the spritesheet; \n" +
+                "default is the Start parameter of the Animation docker"),
+            describedWidget(
+                widget=self.end,
+                descri="End:",
+                tooltip="Last frame of the animation timeline (included) " +
+                "to be added to the spritesheet; \n" +
+                "default is the End parameter of the Animation docker"),
+            describedWidget(
+                widget=self.step,
+                descri="Step:",
+                tooltip="only consider every 'step' frame " +
+                "to be added to the spritesheet; \n" +
+                "default is 1 (use every frame)")])
 
         self.hideableLayout.addWidget(self.spinBoxesWidget)
 
-        self.addDescribedWidget(parent = self.checkBoxes, listWidgets = [
-        describedWidget(
-        descri = "Remove individual sprites?",
-        widget = self.removeTmp,
-        tooltip = "Once the spritesheet export is done, \nwhether to remove the individual exported sprites")])
+        self.addDescribedWidget(parent=self.checkBoxes, listWidgets=[
+            describedWidget(
+                descri="Remove individual sprites?",
+                widget=self.removeTmp,
+                tooltip="Once the spritesheet export is done, \n"
+                + "whether to remove the individual exported sprites")])
 
-        self.overwriteLayout = self.addDescribedWidget(parent = self.hiddenCheckboxLayout, listWidgets = [
-        describedWidget(
-        descri = "Overwrite existant?",
-        widget = self.overwrite,
-        tooltip = "If there is already a folder with the same name as the individual sprites export folder, \nwhether to create a new one (unchecked) or write the sprites in the existing folder, \npossibly overwriting other files (checked)")])
+        self.overwriteLayout = self.addDescribedWidget(
+            parent=self.hiddenCheckboxLayout,
+            listWidgets=[
+                describedWidget(
+                    descri="Overwrite existant?",
+                    widget=self.overwrite,
+                    tooltip="If there is already a folder " +
+                    "with the same name as the individual " +
+                    "sprites export folder, \n" +
+                    "whether to create a new one (unchecked) " +
+                    "or write the sprites in the existing folder, \n"
+                    + "possibly overwriting other files (checked)")])
 
-        #self.hideableLayout.addWidget(self.line2)
-        #self.hideableLayout.addItem(self.spacer)
+        # self.hideableLayout.addWidget(self.line2)
+        # self.hideableLayout.addItem(self.spacer)
 
-
-        self.addDescribedWidget(parent = self.spritesExportDir, listWidgets = [
-        describedWidget(
-        widget = self.spritesExportDirTx,
-        descri = "Sprites export directory:",
-        tooltip = "The directory the individual sprites will be exported to")])
+        self.addDescribedWidget(parent=self.spritesExportDir, listWidgets=[
+            describedWidget(
+                widget=self.spritesExportDirTx,
+                descri="Sprites export directory:",
+                tooltip="The directory the individual sprites " +
+                "will be exported to")])
         self.spritesExportDir.addWidget(self.spritesExportDirButt)
 
         # have removeTmp toggle overwrite's and sprites export dir's visibility
@@ -256,37 +288,43 @@ class UISpritesheetExporter(object):
         self.removeTmp.clicked.connect(self.toggleHiddenParams)
 
         self.outerLayout.addWidget(self.hideableWidget)
-        #self.outerLayout.addItem(self.spacer)
-        #self.outerLayout.addWidget(self.line)
+        # self.outerLayout.addItem(self.spacer)
+        # self.outerLayout.addWidget(self.line)
 
-        #self.hideableWidget.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)  # doesn't work
+        # self.hideableWidget.setSizePolicy(QSizePolicy.Minimum,
+        #                                   QSizePolicy.Minimum)
+        # (doesn't work)
 
         self.outerLayout.addWidget(self.OkCancelButtonBox)
         self.toggleHiddenParams()
         self.toggleHideable()
 
     def exclusiveVertToHor(self):
-        self.exclusiveCheckBoxUpdate(trigger = self.vertDir, triggered = self.horDir)
+        self.exclusiveCheckBoxUpdate(
+            trigger=self.vertDir,
+            triggered=self.horDir)
 
     def exclusiveHorToVert(self):
-        self.exclusiveCheckBoxUpdate(trigger = self.horDir, triggered = self.vertDir)
+        self.exclusiveCheckBoxUpdate(
+            trigger=self.horDir,
+            triggered=self.vertDir)
 
     def exclusiveCheckBoxUpdate(self, trigger, triggered):
         if triggered.isChecked() == trigger.isChecked():
             triggered.setChecked(not trigger.isChecked())
 
     def toggleHideable(self):
-        h = self.mainDialog.height()
-        w = self.mainDialog.width()
+        # h = self.mainDialog.height()
+        # w = self.mainDialog.width()
         if self.customSettings.isChecked():
             self.hideableWidget.show()
-            #self.mainDialog.resize(w, 300)
+            # self.mainDialog.resize(w, 300)
             self.mainDialog.adjustSize()
         else:
             self.hideableWidget.hide()
             # with only one resize it doesn't work
-            #self.mainDialog.resize(w, 0)
-            #self.mainDialog.resize(w, 100)
+            # self.mainDialog.resize(w, 0)
+            # self.mainDialog.resize(w, 100)
             self.mainDialog.adjustSize()
 
     def toggleHiddenParams(self):
@@ -323,16 +361,21 @@ class UISpritesheetExporter(object):
 
     def changeSpritesExportDir(self):
         self.SpritesExportDirDialog = QFileDialog()
-        self.SpritesExportDirDialog.setWindowTitle(i18n("Choose Sprites Export Directory"))
+        self.SpritesExportDirDialog.setWindowTitle(
+            i18n("Choose Sprites Export Directory"))
         self.SpritesExportDirDialog.setSizeGripEnabled(True)
         self.SpritesExportDirDialog.setDirectory(str(self.exportPath))
         # we grab the output path on directory changed
-        self.spritesExportPath = self.SpritesExportDirDialog.getExistingDirectory()
+        self.spritesExportPath = \
+            self.SpritesExportDirDialog.getExistingDirectory()
         if self.spritesExportPath != "":
             self.spritesExportDirTx.setText(str(self.spritesExportPath))
 
     def confirmButton(self):
-        self.mainDialog.setDisabled(True) # so if you double click it doesn't interrupt the first run of the function with a new one
+        self.mainDialog.setDisabled(True)
+        # so if you double click it doesn't interrupt
+        # the first run of the function with a new one
+
         self.exp.exportName = self.exportName.text().split('.')[0]
         self.exp.exportDir = Path(self.exportPath)
         self.exp.isDirectionHorizontal = self.horDir.isChecked()
@@ -346,6 +389,7 @@ class UISpritesheetExporter(object):
         if self.spritesExportDirTx.text() != "":
             self.exp.spritesExportDir = Path(self.spritesExportDirTx.text())
         else:
-            self.exp.spritesExportDir = "" # important: to reset spritesheetexporter's spritesExportDir
+            self.exp.spritesExportDir = ""
+            # important: to reset spritesheetexporter's spritesExportDir
         self.exp.export()
         self.mainDialog.hide()

--- a/spritesheetExporter/uispritesheetexporter.py
+++ b/spritesheetExporter/uispritesheetexporter.py
@@ -7,14 +7,14 @@ UI of the spritesheet exporter user choices dialog
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QGridLayout, QVBoxLayout, QFrame, QPushButton,
                              QVBoxLayout, QHBoxLayout, QFileDialog, QLabel,
-                             QPushButton, QInputDialog, QSpinBox, QDialog, 
+                             QPushButton, QInputDialog, QSpinBox, QDialog,
                              QLineEdit, QWidget, QCheckBox, QDialogButtonBox,
                              QSpacerItem, QSizePolicy)
 import krita
 from pathlib import Path # to have paths work whether it's windows or unix
 from . import spritesheetexporter
 
-        
+
 class describedWidget:
     def __init__ (self, widget, descri, tooltip = ""):
         self.widget = widget
@@ -34,9 +34,9 @@ class UISpritesheetExporter(object):
         self.mainDialog = QDialog(self.app.activeWindow().qwindow()) #the main window
         self.mainDialog.setWindowModality(Qt.NonModal) #The window is not modal and does not block input to other windows.
         self.mainDialog.setMinimumSize(500, 100)
-        
+
         self.outerLayout = QVBoxLayout(self.mainDialog) # the box holding everything
-        
+
         self.topLayout = QVBoxLayout()
 
         # the user should choose the export name of the final spritesheet
@@ -50,7 +50,7 @@ class UISpritesheetExporter(object):
         self.exportDirButt.clicked.connect(self.changeExportDir)
         self.exportDirResetButt.clicked.connect(self.resetExportDir)
         self.exportDir = QHBoxLayout()
-        
+
         # and the sprites export directory
         self.spritesExportDirWidget = QWidget()
         self.spritesExportDirTx = QLineEdit()
@@ -58,16 +58,16 @@ class UISpritesheetExporter(object):
         self.spritesExportDirButt.clicked.connect(self.changeSpritesExportDir)
         self.spritesExportDirTx.setToolTip("Leave empty for default")
         self.spritesExportDir = QHBoxLayout(self.spritesExportDirWidget)
-        
+
         self.customSettings = QCheckBox()
         self.customSettings.setChecked(False)
         self.customSettings.stateChanged.connect(self.toggleHideable)
-        
+
         self.hideableWidget = QFrame() # QFrames are a type of widget
         self.hideableWidget.setFrameShape(QFrame.Panel)
         self.hideableWidget.setFrameShadow(QFrame.Sunken)
         self.hideableLayout = QVBoxLayout(self.hideableWidget)
-        
+
         # we want to let the user choose if they want the final spritesheet to be horizontally- or vertically-oriented
         # there is a nifty thing called QButtonGroup() but it doesn't seem to let you add names between each checkbox somehow?
         self.horDir = QCheckBox()
@@ -116,7 +116,7 @@ class UISpritesheetExporter(object):
         self.OkCancelButtonBox.rejected.connect(self.mainDialog.close)
 
         self.space = 10
-        
+
         self.spacer = QSpacerItem(self.space, self.space)
         self.spacerBig = QSpacerItem(self.space*2, self.space*2)
 
@@ -153,15 +153,15 @@ class UISpritesheetExporter(object):
         self.exportName.setText(self.exp.exportName)
         self.addDescribedWidget(parent = self.topLayout, listWidgets = [
         describedWidget(
-        widget = self.exportName, 
-        descri = "Export name:", 
+        widget = self.exportName,
+        descri = "Export name:",
         tooltip = "The name of the exported spritesheet file")])
         self.addDescribedWidget(parent = self.topLayout, listWidgets = [
         describedWidget(
-        widget = self.exportDirTx, 
-        descri = "Export Directory:", 
+        widget = self.exportDirTx,
+        descri = "Export Directory:",
         tooltip = "The directory the spritesheet will be exported to")])
-        
+
         self.exportDir.addWidget(self.exportDirButt)
         self.exportDir.addWidget(self.exportDirResetButt)
         self.topLayout.addLayout(self.exportDir)
@@ -173,9 +173,9 @@ class UISpritesheetExporter(object):
         widget = self.customSettings,
         descri = "Use Custom export Settings:",
         tooltip = "Whether to set yourself the number of rows, columns, \nfirst and last frame, etc. (checked) \nor use the default values (unchecked) ")])
-        
+
         self.outerLayout.addLayout(self.topLayout, 0)
-        
+
         # all this stuff will be hideable
         self.direction.addWidget(QLabel("sprites placement direction: \t"))
         self.addDescribedWidget(parent = self.direction, listWidgets = [
@@ -183,15 +183,15 @@ class UISpritesheetExporter(object):
         widget = self.horDir,
         descri = "Horizontal:",
         tooltip = "like so: \n1, 2, 3 \n4, 5, 6 \n7, 8, 9")])
-        
+
         self.addDescribedWidget(parent = self.direction, listWidgets = [
         describedWidget(
         widget = self.vertDir,
         descri = "Vertical:",
         tooltip = "like so: \n1, 4, 7 \n2, 5, 8 \n3, 6, 9")])
-        
+
         self.hideableLayout.addLayout(self.direction)
-        
+
         self.hideableLayout.addItem(self.spacerBig)
 
         defaultsHint = QLabel("Leave any parameter at 0 to get a default value:")
@@ -201,26 +201,26 @@ class UISpritesheetExporter(object):
 
         self.addDescribedWidget(parent = self.spinBoxes, listWidgets = [
         describedWidget(
-        widget = self.rows, 
-        descri = "Rows:", 
-        tooltip = "Number of rows of the spritesheet; \ndefault is trying to square \nor is assigned depending on columns number"), 
+        widget = self.rows,
+        descri = "Rows:",
+        tooltip = "Number of rows of the spritesheet; \ndefault is trying to square \nor is assigned depending on columns number"),
         describedWidget(
-        widget = self.columns, 
-        descri = "Columns:", 
+        widget = self.columns,
+        descri = "Columns:",
         tooltip = "Number of columns of the spritesheet; \ndefault is trying to square \nor is assigned depending on rows number")])
-        
+
         self.addDescribedWidget(parent = self.spinBoxes, listWidgets = [
         describedWidget(
-        widget = self.start, 
-        descri = "Start:", 
-        tooltip = "First frame of the animation timeline (included) to be added to the spritesheet; \ndefault is the Start parameter of the Animation docker"), 
+        widget = self.start,
+        descri = "Start:",
+        tooltip = "First frame of the animation timeline (included) to be added to the spritesheet; \ndefault is the Start parameter of the Animation docker"),
         describedWidget(
-        widget = self.end, 
-        descri = "End:", 
-        tooltip = "Last frame of the animation timeline (included) to be added to the spritesheet; \ndefault is the End parameter of the Animation docker"), 
+        widget = self.end,
+        descri = "End:",
+        tooltip = "Last frame of the animation timeline (included) to be added to the spritesheet; \ndefault is the End parameter of the Animation docker"),
         describedWidget(
-        widget = self.step, 
-        descri = "Step:", 
+        widget = self.step,
+        descri = "Step:",
         tooltip = "only consider every 'step' frame to be added to the spritesheet; \ndefault is 1 (use every frame)")])
 
 
@@ -228,27 +228,27 @@ class UISpritesheetExporter(object):
 
         self.addDescribedWidget(parent = self.checkBoxes, listWidgets = [
         describedWidget(
-        descri = "Remove individual sprites?", 
-        widget = self.removeTmp, 
+        descri = "Remove individual sprites?",
+        widget = self.removeTmp,
         tooltip = "Once the spritesheet export is done, \nwhether to remove the individual exported sprites")])
-        
+
         self.overwriteLayout = self.addDescribedWidget(parent = self.hiddenCheckboxLayout, listWidgets = [
         describedWidget(
-        descri = "Overwrite existant?", 
-        widget = self.overwrite, 
+        descri = "Overwrite existant?",
+        widget = self.overwrite,
         tooltip = "If there is already a folder with the same name as the individual sprites export folder, \nwhether to create a new one (unchecked) or write the sprites in the existing folder, \npossibly overwriting other files (checked)")])
-        
+
         #self.hideableLayout.addWidget(self.line2)
         #self.hideableLayout.addItem(self.spacer)
-        
-        
+
+
         self.addDescribedWidget(parent = self.spritesExportDir, listWidgets = [
         describedWidget(
-        widget = self.spritesExportDirTx, 
-        descri = "Sprites export directory:", 
+        widget = self.spritesExportDirTx,
+        descri = "Sprites export directory:",
         tooltip = "The directory the individual sprites will be exported to")])
         self.spritesExportDir.addWidget(self.spritesExportDirButt)
-        
+
         # have removeTmp toggle overwrite's and sprites export dir's visibility
         self.checkBoxes.addWidget(self.hiddenCheckbox)
         self.hideableLayout.addLayout(self.checkBoxes)
@@ -270,7 +270,7 @@ class UISpritesheetExporter(object):
 
     def exclusiveHorToVert(self):
         self.exclusiveCheckBoxUpdate(trigger = self.horDir, triggered = self.vertDir)
-        
+
     def exclusiveCheckBoxUpdate(self, trigger, triggered):
         if triggered.isChecked() == trigger.isChecked():
             triggered.setChecked(not trigger.isChecked())


### PR DESCRIPTION
This PR puts the code in compliance with the `flake8` linter (mostly).

To see the alerts before and after, just run `flake8 *.py` in the relevant directory -- you need to install `flake8` first.

I don't have the Krita scripting libraries on my machine, so I didn't test the result. The changes are mostly whitespace changes, and they are painful to review manually (very boring!), so I would recommend testing and merging if you don't see any behavior change.