### PR TITLE
add export to texture atlas

### DIFF
--- a/spritesheetExporter/Manual.html
+++ b/spritesheetExporter/Manual.html
@@ -26,6 +26,17 @@ This plugin allows you to easily export the active animation as a spritesheet wi
 <b>export directory</b>: select the folder in which the spritesheet will be exported (the frames will be exported in a subfolder of the export directory called exportName_sprites if no <b>sprites export directory</b> is set)<br>
 <b>change export directory</b>: Opens a file explorer to select the Export Directory<br>
 <b>reset to current directory</b>: Resets the export directory to the directory containing the currently active .kra document<br>
+  <b>write json texture atlas</b>: Writes a json texture atlas file that can be used e.g. in the Phaser 3 game framework. The atlas filename will be "exportName.json"
+The filenames in the atlas file will be set to the numeric index of the texture. Example:
+  <pre>
+{ "frames": [
+    { "filename": 0,
+      "frame": { "x": 0, "y": 0, "w": 300, "h": 334 } },
+    { "filename": 1,
+      "frame": { "x": 300, "y": 0, "w": 300, "h": 334 } },
+...
+</pre>
+<br>
 <b>use layers as animation frames</b>: instead of exporting a spritesheet using each frame, export one using each visible layer (for the current frame); for people who have files formatted the photoshop way (timeline and layers on the same axis), or for those who don't export actual animations but sketches or something<br>
 <b>export direction</b>: How the frames are placed. For example, in a 3*2 grid, frame numbers are as follows:<br>
 if horizontal:<br>

--- a/spritesheetExporter/spritesheetexporter.py
+++ b/spritesheetExporter/spritesheetexporter.py
@@ -1,5 +1,6 @@
 from krita import (krita, InfoObject)
 from math import sqrt, ceil, floor
+import json
 
 from . import uispritesheetexporter
 # manages the dialog that lets you set user preferences
@@ -34,6 +35,7 @@ class SpritesheetExporter(object):
         self.removeTmp = True
         self.step = 1
         self.layersAsAnimation = False
+        self.writeTextureAtlas = False
         self.layersList = []
         self.layersStates = []
         self.offLayers = 0
@@ -337,6 +339,7 @@ class SpritesheetExporter(object):
         invisibleLayersNum = 0
 
 
+        textureAtlas = { "frames": [ ] }
         while (frameIDNum <= self.end):
             doc.waitForDone()
             if(not self.layersAsAnimation or (self.layersAsAnimation and self.layersStates[frameIDNum])):
@@ -359,6 +362,13 @@ class SpritesheetExporter(object):
                     debugPrint("adding to spritesheet, image " + str(frameIDNum-self.start) +
                           " name: " + img +
                           " at pos: " + str(layer.position()))
+                if (self.writeTextureAtlas):
+                    textureAtlas["frames"].append({
+                        "filename": frameIDNum,
+                        "frame": { "x": layer.position().x(),
+                                   "y": layer.position().y(),
+                                   "w": width,
+                                   "h": height}})
             else:
                 invisibleLayersNum += 1
             frameIDNum += self.step
@@ -369,6 +379,10 @@ class SpritesheetExporter(object):
             debugPrint("exporting spritesheet to " + str(sheetExportPath()))
 
         sheet.exportImage(str(sheetExportPath(".png")), InfoObject())
+
+        if (self.writeTextureAtlas):
+            with open(str(sheetExportPath(".json")), 'w') as f:
+                json.dump(textureAtlas, f)
 
         # and remove the empty tmp folder when you're done
         if self.removeTmp:

--- a/spritesheetExporter/uispritesheetexporter.py
+++ b/spritesheetExporter/uispritesheetexporter.py
@@ -78,6 +78,9 @@ class UISpritesheetExporter(object):
         self.layersAsAnimation = QCheckBox()
         self.layersAsAnimation.setChecked(False)
 
+        self.writeTextureAtlas = QCheckBox()
+        self.writeTextureAtlas.setChecked(False)
+
         # We want to let the user choose if they want the final spritesheet
         # to be horizontally- or vertically-oriented.
         # There is a nifty thing called QButtonGroup() but
@@ -176,6 +179,14 @@ class UISpritesheetExporter(object):
         self.exportDir.addWidget(self.exportDirButt)
         self.exportDir.addWidget(self.exportDirResetButt)
         self.topLayout.addLayout(self.exportDir)
+
+        self.addDescribedWidget(parent=self.topLayout, listWidgets=[
+            describedWidget(
+                descri="Write json texture atlas ",
+                widget=self.writeTextureAtlas,
+                tooltip="" +
+                "Write a json texture atlas that can be\n" +
+                "used in e.g. the Phaser 3 game framework")])
 
         self.addDescribedWidget(parent=self.topLayout, listWidgets=[
             describedWidget(
@@ -386,6 +397,7 @@ class UISpritesheetExporter(object):
         self.exp.exportName = self.exportName.text().split('.')[0]
         self.exp.exportDir = Path(self.exportPath)
         self.exp.layersAsAnimation = self.layersAsAnimation.isChecked()
+        self.exp.writeTextureAtlas = self.writeTextureAtlas.isChecked()
         self.exp.isDirectionHorizontal = self.horDir.isChecked()
         self.exp.rows = self.rows.value()
         self.exp.columns = self.columns.value()


### PR DESCRIPTION
Hi Falano,

first of all thanks for your great plugin which allows me to export Krita animations to sprite sheets. What was missing to use the sprite sheets in the Phaser 3 game framework was the texture atlas json file.

I've added a checkbox for the atlas creation, defaulting to false. If checked, a json file with the same base name as the exported image file will be written to.

Eugen