### PR TITLE
Fix transparent background in spritesheet

### DIFF
--- a/spritesheetExporter/spritesheetexporter.py
+++ b/spritesheetExporter/spritesheetexporter.py
@@ -336,6 +336,7 @@ class SpritesheetExporter(object):
         # adding our sprites to the new document
         # and moving them to the right position
         root_node = sheet.rootNode()
+        root_node.childNodes()[0].setVisible(False) # hide the default layer filled with white
         invisibleLayersNum = 0
 
 


### PR DESCRIPTION
It's a quick fix for #19

[Krita::createDocument](https://api.kde.org/krita/html/classKrita.html#ac6e4d03d3ef97d5d8423e854d0f288b1) creates a document with one transparent layer, but for some reason it's filled with white by default